### PR TITLE
improve `emscripten` detection by including `emcc.py` search

### DIFF
--- a/xmake/modules/detect/sdks/find_emsdk.lua
+++ b/xmake/modules/detect/sdks/find_emsdk.lua
@@ -33,9 +33,16 @@ function _find_emsdkdir(sdkdir)
         table.insert(paths, sdkdir)
     end
     table.insert(paths, "$(env EMSDK)")
+    if is_host("linux") then
+        table.join2(paths, {"/usr/share/emscripten/", "/usr/lib/emscripten/"})
+    end
     local emsdk = find_file("emsdk.py", paths, {suffixes = subdirs})
     if emsdk then
         return path.directory(emsdk)
+    end
+    local emcc_py = find_file("emcc.py", paths, {suffixes = subdirs})
+    if emcc_py then
+        return path.directory(emcc_py)
     end
 end
 
@@ -53,6 +60,7 @@ function _find_emsdk(sdkdir)
     local subdirs = {}
     table.insert(subdirs, path.join("*", "emscripten"))
     local emcc = find_file("emcc", sdkdir, {suffixes = subdirs})
+    emcc = emcc or find_file("emcc.py", sdkdir)
     if emcc then
         emscripten = path.directory(emcc)
     end


### PR DESCRIPTION
As discussed in, the `emscripten` package in the [APT repository](https://packages.debian.org/bookworm/all/emscripten/filelist) does not include `emsdk.py`, leading to detection issues in xmake.

This PR improves detection by also searching for `emcc.py`, which aids in locating the installed `emscripten`. However, specifying the `emsdk` path may still be necessary. For example:

- On Debian: `xmake g --emsdk=/usr/share/emscripten/`
- On Arch: `xmake g --emsdk=/usr/lib/emscripten`

(Note: The `emscripten` installation path may change in the future, so the paths mentioned here might become outdated.)